### PR TITLE
Add docs-snippet package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ RUN apm install atom-beautify
 RUN apm install cucumber
 RUN apm install cucumber-step
 RUN apm install cucumber-autocomplete
+RUN apm install docs-snippets
 
 # autorun atom
 ENTRYPOINT [ "atom", "--foreground" ]


### PR DESCRIPTION
It supports [tomdoc](http://tomdoc.org/) :)

@caiobonfante I would like to add the [git-time-machine](https://atom.io/packages/git-time-machine) plugin also, but it does not have a simple apm command to install it.
Could you help me to:
1. Teste the docs-snippet package installation?
2. Check how to install git-time-machine package?

:smile: 